### PR TITLE
Simplify the import experience

### DIFF
--- a/.g8/checkboxPage/app/models/$className$.scala
+++ b/.g8/checkboxPage/app/models/$className$.scala
@@ -3,11 +3,11 @@ package models
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.checkboxes.CheckboxItem
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
-import viewmodels.govuk.CheckboxFluency
+import viewmodels.govuk.checkbox._
 
 sealed trait $className$
 
-object $className$ extends Enumerable.Implicits with CheckboxFluency {
+object $className$ extends Enumerable.Implicits {
 
   case object $option1key;format="Camel"$ extends WithName("$option1key;format="decap"$") with $className$
   case object $option2key;format="Camel"$ extends WithName("$option2key;format="decap"$") with $className$

--- a/.g8/checkboxPage/app/viewmodels/checkAnswers/$className$Summary.scala
+++ b/.g8/checkboxPage/app/viewmodels/checkAnswers/$className$Summary.scala
@@ -7,10 +7,9 @@ import play.api.i18n.Messages
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
-import viewmodels.govuk.SummaryListFluency
-import viewmodels.ImplicitConversions._
+import viewmodels.govuk._
 
-object $className$Summary extends SummaryListFluency {
+object $className$Summary {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
     answers.get($className$Page).map {

--- a/.g8/datePage/app/viewmodels/checkAnswers/$className$Summary.scala
+++ b/.g8/datePage/app/viewmodels/checkAnswers/$className$Summary.scala
@@ -7,10 +7,9 @@ import models.{CheckMode, UserAnswers}
 import pages.$className$Page
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
-import viewmodels.govuk.SummaryListFluency
-import viewmodels.ImplicitConversions._
+import viewmodels.govuk._
 
-object $className$Summary extends SummaryListFluency {
+object $className$Summary {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
     answers.get($className$Page).map {

--- a/.g8/intPage/app/viewmodels/checkAnswers/$className$Summary.scala
+++ b/.g8/intPage/app/viewmodels/checkAnswers/$className$Summary.scala
@@ -5,10 +5,9 @@ import models.{CheckMode, UserAnswers}
 import pages.$className$Page
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
-import viewmodels.govuk.SummaryListFluency
-import viewmodels.ImplicitConversions._
+import viewmodels.govuk._
 
-object $className$Summary extends SummaryListFluency {
+object $className$Summary {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
     answers.get($className$Page).map {

--- a/.g8/optionsPage/app/viewmodels/checkAnswers/$className$Summary.scala
+++ b/.g8/optionsPage/app/viewmodels/checkAnswers/$className$Summary.scala
@@ -7,10 +7,9 @@ import play.api.i18n.Messages
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
-import viewmodels.govuk.SummaryListFluency
-import viewmodels.ImplicitConversions._
+import viewmodels.govuk._
 
-object $className$Summary extends SummaryListFluency {
+object $className$Summary {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
     answers.get($className$Page).map {

--- a/.g8/questionPage/app/viewmodels/checkAnswers/$className$Summary.scala
+++ b/.g8/questionPage/app/viewmodels/checkAnswers/$className$Summary.scala
@@ -7,10 +7,9 @@ import play.api.i18n.Messages
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
-import viewmodels.govuk.SummaryListFluency
-import viewmodels.ImplicitConversions._
+import viewmodels.govuk._
 
-object $className$Summary extends SummaryListFluency {
+object $className$Summary {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
     answers.get($className$Page).map {

--- a/.g8/stringPage/app/viewmodels/checkAnswers/$className$Summary.scala
+++ b/.g8/stringPage/app/viewmodels/checkAnswers/$className$Summary.scala
@@ -6,10 +6,9 @@ import pages.$className$Page
 import play.api.i18n.Messages
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
-import viewmodels.govuk.SummaryListFluency
-import viewmodels.ImplicitConversions._
+import viewmodels.govuk._
 
-object $className$Summary extends SummaryListFluency {
+object $className$Summary {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
     answers.get($className$Page).map {

--- a/.g8/yesNoPage/app/viewmodels/checkAnswers/$className$Summary.scala
+++ b/.g8/yesNoPage/app/viewmodels/checkAnswers/$className$Summary.scala
@@ -5,10 +5,9 @@ import models.{CheckMode, UserAnswers}
 import pages.$className$Page
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
-import viewmodels.govuk.SummaryListFluency
-import viewmodels.ImplicitConversions._
+import viewmodels.govuk._
 
-object $className$Summary extends SummaryListFluency {
+object $className$Summary {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
     answers.get($className$Page).map {

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ bin
 /*.ipr
 /.classpath
 *.iws
+.bloop/
+.metals/
+.vscode/
+metals.sbt

--- a/app/controllers/CheckYourAnswersController.scala
+++ b/app/controllers/CheckYourAnswersController.scala
@@ -22,7 +22,7 @@ import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import viewmodels.checkAnswers._
-import viewmodels.govuk.SummaryListFluency
+import viewmodels.govuk.summarylist._
 import views.html.CheckYourAnswersView
 
 class CheckYourAnswersController @Inject()(
@@ -32,7 +32,7 @@ class CheckYourAnswersController @Inject()(
                                             requireData: DataRequiredAction,
                                             val controllerComponents: MessagesControllerComponents,
                                             view: CheckYourAnswersView
-                                          ) extends FrontendBaseController with I18nSupport with SummaryListFluency {
+                                          ) extends FrontendBaseController with I18nSupport {
 
   def onPageLoad(): Action[AnyContent] = (identify andThen getData andThen requireData) {
     implicit request =>

--- a/app/models/CheckboxExample.scala
+++ b/app/models/CheckboxExample.scala
@@ -19,11 +19,11 @@ package models
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.checkboxes.CheckboxItem
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
-import viewmodels.govuk.CheckboxFluency
+import viewmodels.govuk.checkbox._
 
 sealed trait CheckboxExample
 
-object CheckboxExample extends Enumerable.Implicits with CheckboxFluency {
+object CheckboxExample extends Enumerable.Implicits {
 
   case object Option1 extends WithName("option1") with CheckboxExample
   case object Option2 extends WithName("option2") with CheckboxExample

--- a/app/viewmodels/ImplicitConversions.scala
+++ b/app/viewmodels/ImplicitConversions.scala
@@ -22,8 +22,9 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.Key
 
 import scala.language.implicitConversions
 
-object ImplicitConversions {
+object ImplicitConversions extends ImplicitConversions
 
+trait ImplicitConversions {
   implicit def stringToText(string: String)(implicit messages: Messages): Text =
     Text(messages(string))
 

--- a/app/viewmodels/checkAnswers/CheckboxExampleSummary.scala
+++ b/app/viewmodels/checkAnswers/CheckboxExampleSummary.scala
@@ -23,10 +23,9 @@ import play.api.i18n.Messages
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
-import viewmodels.govuk.SummaryListFluency
-import viewmodels.ImplicitConversions._
+import viewmodels.govuk._
 
-object CheckboxExampleSummary extends SummaryListFluency {
+object CheckboxExampleSummary {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
     answers.get(CheckboxExamplePage).map {

--- a/app/viewmodels/checkAnswers/DateExampleSummary.scala
+++ b/app/viewmodels/checkAnswers/DateExampleSummary.scala
@@ -23,10 +23,9 @@ import models.{CheckMode, UserAnswers}
 import pages.DateExamplePage
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
-import viewmodels.govuk.SummaryListFluency
-import viewmodels.ImplicitConversions._
+import viewmodels.govuk._
 
-object DateExampleSummary extends SummaryListFluency {
+object DateExampleSummary {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
     answers.get(DateExamplePage).map {

--- a/app/viewmodels/checkAnswers/IntExampleSummary.scala
+++ b/app/viewmodels/checkAnswers/IntExampleSummary.scala
@@ -21,10 +21,9 @@ import models.{CheckMode, UserAnswers}
 import pages.IntExamplePage
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
-import viewmodels.govuk.SummaryListFluency
-import viewmodels.ImplicitConversions._
+import viewmodels.govuk._
 
-object IntExampleSummary extends SummaryListFluency {
+object IntExampleSummary {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
     answers.get(IntExamplePage).map {

--- a/app/viewmodels/checkAnswers/OptionsExampleSummary.scala
+++ b/app/viewmodels/checkAnswers/OptionsExampleSummary.scala
@@ -23,10 +23,9 @@ import play.api.i18n.Messages
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
-import viewmodels.govuk.SummaryListFluency
-import viewmodels.ImplicitConversions._
+import viewmodels.govuk._
 
-object OptionsExampleSummary extends SummaryListFluency {
+object OptionsExampleSummary {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
     answers.get(OptionsExamplePage).map {

--- a/app/viewmodels/checkAnswers/QuestionExampleSummary.scala
+++ b/app/viewmodels/checkAnswers/QuestionExampleSummary.scala
@@ -23,10 +23,9 @@ import play.api.i18n.Messages
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
-import viewmodels.govuk.SummaryListFluency
-import viewmodels.ImplicitConversions._
+import viewmodels.govuk._
 
-object QuestionExampleSummary extends SummaryListFluency {
+object QuestionExampleSummary {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
     answers.get(QuestionExamplePage).map {

--- a/app/viewmodels/checkAnswers/StringExampleSummary.scala
+++ b/app/viewmodels/checkAnswers/StringExampleSummary.scala
@@ -22,10 +22,9 @@ import pages.StringExamplePage
 import play.api.i18n.Messages
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
-import viewmodels.govuk.SummaryListFluency
-import viewmodels.ImplicitConversions._
+import viewmodels.govuk._
 
-object StringExampleSummary extends SummaryListFluency {
+object StringExampleSummary {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
     answers.get(StringExamplePage).map {

--- a/app/viewmodels/checkAnswers/YesNoExampleSummary.scala
+++ b/app/viewmodels/checkAnswers/YesNoExampleSummary.scala
@@ -21,10 +21,9 @@ import models.{CheckMode, UserAnswers}
 import pages.YesNoExamplePage
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.SummaryListRow
-import viewmodels.govuk.SummaryListFluency
-import viewmodels.ImplicitConversions._
+import viewmodels.govuk._
 
-object YesNoExampleSummary extends SummaryListFluency {
+object YesNoExampleSummary {
 
   def row(answers: UserAnswers)(implicit messages: Messages): Option[SummaryListRow] =
     answers.get(YesNoExamplePage).map {

--- a/app/viewmodels/govuk.scala
+++ b/app/viewmodels/govuk.scala
@@ -16,19 +16,17 @@
 
 package viewmodels
 
-package object govuk {
-
-  object GovukFluency
-    extends BackLinkFluency
-      with ButtonFluency
-      with CheckboxFluency
-      with DateFluency
-      with ErrorSummaryFluency
-      with FieldsetFluency
-      with HintFluency
-      with InputFluency
-      with LabelFluency
-      with PhaseBannerFluency
-      with RadiosFluency
-      with TagFluency
-}
+package object govuk
+  extends ImplicitConversions
+  with govuk.BackLinkFluency
+  with govuk.ButtonFluency
+  with govuk.CheckboxFluency
+  with govuk.DateFluency
+  with govuk.ErrorSummaryFluency
+  with govuk.FieldsetFluency
+  with govuk.HintFluency
+  with govuk.InputFluency
+  with govuk.LabelFluency
+  with govuk.PhaseBannerFluency
+  with govuk.RadiosFluency
+  with govuk.SummaryListFluency

--- a/app/viewmodels/govuk/backlink.scala
+++ b/app/viewmodels/govuk/backlink.scala
@@ -20,6 +20,8 @@ import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.Aliases.Text
 import uk.gov.hmrc.govukfrontend.views.viewmodels.backlink.BackLink
 
+object backlink extends BackLinkFluency
+
 trait BackLinkFluency {
 
   object BackLinkViewModel {

--- a/app/viewmodels/govuk/button.scala
+++ b/app/viewmodels/govuk/button.scala
@@ -19,6 +19,8 @@ package viewmodels.govuk
 import uk.gov.hmrc.govukfrontend.views.viewmodels.button.Button
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Content
 
+object button extends ButtonFluency
+
 trait ButtonFluency {
 
   object ButtonViewModel {

--- a/app/viewmodels/govuk/checkbox.scala
+++ b/app/viewmodels/govuk/checkbox.scala
@@ -26,6 +26,8 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.hint.Hint
 import uk.gov.hmrc.govukfrontend.views.viewmodels.label.Label
 import viewmodels.ErrorMessageAwareness
 
+object checkbox extends CheckboxFluency
+
 trait CheckboxFluency {
 
   object CheckboxesViewModel extends ErrorMessageAwareness with FieldsetFluency {

--- a/app/viewmodels/govuk/date.scala
+++ b/app/viewmodels/govuk/date.scala
@@ -23,6 +23,8 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.fieldset.{Fieldset, Legend}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.hint.Hint
 import viewmodels.ErrorMessageAwareness
 
+object date extends DateFluency
+
 trait DateFluency {
 
   object DateViewModel extends ErrorMessageAwareness {

--- a/app/viewmodels/govuk/errorsummary.scala
+++ b/app/viewmodels/govuk/errorsummary.scala
@@ -21,6 +21,8 @@ import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.{Content, Text}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.errorsummary.{ErrorLink, ErrorSummary}
 
+object errorsummary extends ErrorSummaryFluency
+
 trait ErrorSummaryFluency {
 
   object ErrorSummaryViewModel {

--- a/app/viewmodels/govuk/fieldset.scala
+++ b/app/viewmodels/govuk/fieldset.scala
@@ -21,6 +21,8 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Content
 import uk.gov.hmrc.govukfrontend.views.viewmodels.fieldset.{Fieldset, Legend}
 import viewmodels.LegendSize
 
+object fieldset extends FieldsetFluency
+
 trait FieldsetFluency {
 
   object FieldsetViewModel {

--- a/app/viewmodels/govuk/hint.scala
+++ b/app/viewmodels/govuk/hint.scala
@@ -19,6 +19,8 @@ package viewmodels.govuk
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Content
 import uk.gov.hmrc.govukfrontend.views.viewmodels.hint.Hint
 
+object hint extends HintFluency
+
 trait HintFluency {
 
   object HintViewModel {

--- a/app/viewmodels/govuk/input.scala
+++ b/app/viewmodels/govuk/input.scala
@@ -23,6 +23,8 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.input.{Input, PrefixOrSuffix}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.label.Label
 import viewmodels.{ErrorMessageAwareness, InputWidth}
 
+object input extends InputFluency
+
 trait InputFluency {
 
   object InputViewModel extends ErrorMessageAwareness {

--- a/app/viewmodels/govuk/label.scala
+++ b/app/viewmodels/govuk/label.scala
@@ -20,6 +20,8 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Content
 import uk.gov.hmrc.govukfrontend.views.viewmodels.label.Label
 import viewmodels.LabelSize
 
+object label extends LabelFluency
+
 trait LabelFluency {
 
   object LabelViewModel {

--- a/app/viewmodels/govuk/phasebanner.scala
+++ b/app/viewmodels/govuk/phasebanner.scala
@@ -19,8 +19,11 @@ package viewmodels.govuk
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.{HtmlContent, Text}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.phasebanner.PhaseBanner
+import viewmodels.govuk.tag._
 
-trait PhaseBannerFluency extends TagFluency {
+object phasebanner extends PhaseBannerFluency
+
+trait PhaseBannerFluency {
 
   object PhaseBannerViewModel {
 

--- a/app/viewmodels/govuk/radios.scala
+++ b/app/viewmodels/govuk/radios.scala
@@ -24,9 +24,11 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.hint.Hint
 import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.{RadioItem, Radios}
 import viewmodels.ErrorMessageAwareness
 
+object radios extends RadiosFluency
+
 trait RadiosFluency {
 
-  object RadiosViewModel extends ErrorMessageAwareness with FieldsetFluency {
+  object RadiosViewModel extends ErrorMessageAwareness {
 
     def apply(
                field: Field,

--- a/app/viewmodels/govuk/summarylist.scala
+++ b/app/viewmodels/govuk/summarylist.scala
@@ -19,6 +19,8 @@ package viewmodels.govuk
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Content
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist._
 
+object summarylist extends SummaryListFluency
+
 trait SummaryListFluency {
 
   object SummaryListViewModel {

--- a/app/viewmodels/govuk/tag.scala
+++ b/app/viewmodels/govuk/tag.scala
@@ -19,6 +19,8 @@ package viewmodels.govuk
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Content
 import uk.gov.hmrc.govukfrontend.views.viewmodels.tag.Tag
 
+object tag extends TagFluency
+
 trait TagFluency {
 
   object TagViewModel {

--- a/build.sbt
+++ b/build.sbt
@@ -35,8 +35,7 @@ lazy val root = (project in file("."))
       "views.ViewUtils._",
       "models.Mode",
       "controllers.routes._",
-      "viewmodels.govuk.GovukFluency._",
-      "viewmodels.ImplicitConversions._"
+      "viewmodels.govuk._",
     ),
     PlayKeys.playDefaultPort := 9000,
     ScoverageKeys.coverageExcludedFiles := "<empty>;Reverse.*;.*handlers.*;.*components.*;" +


### PR DESCRIPTION
Vaguely inspired by https://github.com/typelevel/cats/blob/v1.0.0/core/src/main/scala/cats/syntax/package.scala

This means that users only need to `import viewmodels.govuk._` to get all syntax and conversions, or for example `import viewmodels.checkbox._` to get a specific bit of syntax.